### PR TITLE
Support capabilities on center slotted and unslotted parts

### DIFF
--- a/src/main/java/mcmultipart/capabilities/MultipartCapabilityHelper.java
+++ b/src/main/java/mcmultipart/capabilities/MultipartCapabilityHelper.java
@@ -20,7 +20,7 @@ public class MultipartCapabilityHelper {
 
         for (EnumFacing face : EnumFacing.VALUES)
             if (face != side && face.getOpposite() != side && hasCapability(container, capability, side, face)) return true;
-        return false;
+        return hasCapability(container, capability, side, null);
     }
 
     public static <T> T getCapability(IMultipartContainer container, Capability<T> capability, EnumFacing side) {
@@ -32,6 +32,12 @@ public class MultipartCapabilityHelper {
                 if (impl != null) implementations.add(impl);
             }
         }
+
+        {
+            T impl = getCapability(container, capability, side, null);
+            if (impl != null) implementations.add(impl);
+        }
+
         if (implementations.isEmpty()) return null;
         else if (implementations.size() == 1) return implementations.iterator().next();
         else return CapabilityWrapperRegistry.wrap(capability, implementations);
@@ -68,7 +74,7 @@ public class MultipartCapabilityHelper {
 
         for (IMultipart p : container.getParts())
             if (side == null || !(p instanceof ISlottedPart) || ((ISlottedPart) p).getSlotMask().isEmpty())
-                if (p instanceof ICapabilityProvider) return ((ICapabilityProvider) p).hasCapability(capability, side);
+                if (p instanceof ICapabilityProvider && ((ICapabilityProvider) p).hasCapability(capability, side)) return true;
 
         return false;
     }


### PR DESCRIPTION
Failing all faces and edges, check for capabilities with `face == null` (this case was already handled by the helper class, but was never called from the simple `hasCapability` method (and thus the multipart tile entity)). This way if no part is in an outer slot for a requested side, a capability on the center part may be returned (via `container.getPartInSlot(slot = PartSlot.getFaceSlot(face))` because `getFaceSlot` for `null` is `CENTER`). This allows a center part to decide if it wants to expose a capability or not.

I considered also adding a slot occlusion check (i.e. don't ask the center part if the outer slot for the requested side is occluded/solid), but since for my use case that would have had no effect (C&B parts don't occlude slots, so I need an AABB occlusion test anyway), I decided to keep the changeset small.

Furthermore this now checks all parts to see if _any_ single one has a specified capability, instead of returning `false` if the first part we happen to ask doesn't have the specified capability. This is also more in line with `getCapabilites` which also queries all parts that answer with `true` from `hasCapabilities`.

Merging this would be much appreciated, since I'd otherwise need to put my capabilities in the actual multipart tile entity (via event) to be able to return it for my center slotted part (a cable). Thanks!
