### PR TITLE
Fix player falling too fast into a hole with multiparts on the sides, 1.12 edition

### DIFF
--- a/src/main/java/mcmultipart/block/BlockMultipartContainer.java
+++ b/src/main/java/mcmultipart/block/BlockMultipartContainer.java
@@ -549,6 +549,7 @@ public class BlockMultipartContainer extends Block implements ITileEntityProvide
 
     @Override
     public void onLanded(World world, Entity entity) {
+        super.onLanded(world, entity);
         // TODO: Maybe? We need to check collision with the individual parts
     }
 


### PR DESCRIPTION
onLanded() must set motionY to 0