### PR TITLE
Fix #101

### DIFF
--- a/src/main/java/mcmultipart/api/item/ItemBlockMultipart.java
+++ b/src/main/java/mcmultipart/api/item/ItemBlockMultipart.java
@@ -93,8 +93,7 @@ public class ItemBlockMultipart extends ItemBlock {
 
     public static boolean placePartAt(ItemStack stack, EntityPlayer player, EnumHand hand, World world, BlockPos pos, EnumFacing facing,
             float hitX, float hitY, float hitZ, IMultipart multipartBlock, IBlockState state) {
-        Block block = multipartBlock.getBlock();
-        if (!block.canPlaceBlockAt(world, pos) || !block.canPlaceBlockOnSide(world, pos, facing))
+        if (!multipartBlock.canPlacePartAt(world, pos) || !multipartBlock.canPlacePartOnSide(world, pos, facing))
             return false;
 
         IPartSlot slot = multipartBlock.getSlotForPlacement(world, pos, state, facing, hitX, hitY, hitZ, player);

--- a/src/main/java/mcmultipart/api/item/ItemBlockMultipart.java
+++ b/src/main/java/mcmultipart/api/item/ItemBlockMultipart.java
@@ -80,21 +80,23 @@ public class ItemBlockMultipart extends ItemBlock {
             return true;
         }
         bb = multipartBlock.getCollisionBoundingBox(world, pos, state);
-        if ((bb == null || world.checkNoEntityCollision(bb.offset(pos)))
-                && partLogic.placePart(stack, player, hand, world, pos, facing, hitX, hitY, hitZ, multipartBlock, state)) {
-            return true;
-        }
-        return false;
+        return (bb == null || world.checkNoEntityCollision(bb.offset(pos)))
+                && partLogic.placePart(stack, player, hand, world, pos, facing, hitX, hitY, hitZ, multipartBlock, state);
     }
 
     public boolean placeBlockAtTested(ItemStack stack, EntityPlayer player, World world, BlockPos pos, EnumFacing facing, float hitX,
             float hitY, float hitZ, IBlockState newState) {
         return player.canPlayerEdit(pos, facing, stack) && world.getBlockState(pos).getBlock().isReplaceable(world, pos)
-                && block.canPlaceBlockAt(world, pos) && super.placeBlockAt(stack, player, world, pos, facing, hitX, hitY, hitZ, newState);
+                && block.canPlaceBlockAt(world, pos) && block.canPlaceBlockOnSide(world, pos, facing)
+                && super.placeBlockAt(stack, player, world, pos, facing, hitX, hitY, hitZ, newState);
     }
 
     public static boolean placePartAt(ItemStack stack, EntityPlayer player, EnumHand hand, World world, BlockPos pos, EnumFacing facing,
             float hitX, float hitY, float hitZ, IMultipart multipartBlock, IBlockState state) {
+        Block block = multipartBlock.getBlock();
+        if (!block.canPlaceBlockAt(world, pos) || !block.canPlaceBlockOnSide(world, pos, facing))
+            return false;
+
         IPartSlot slot = multipartBlock.getSlotForPlacement(world, pos, state, facing, hitX, hitY, hitZ, player);
         if (MultipartHelper.addPart(world, pos, slot, state, false)) {
             if (!world.isRemote) {

--- a/src/main/java/mcmultipart/api/item/ItemBlockMultipart.java
+++ b/src/main/java/mcmultipart/api/item/ItemBlockMultipart.java
@@ -93,10 +93,10 @@ public class ItemBlockMultipart extends ItemBlock {
 
     public static boolean placePartAt(ItemStack stack, EntityPlayer player, EnumHand hand, World world, BlockPos pos, EnumFacing facing,
             float hitX, float hitY, float hitZ, IMultipart multipartBlock, IBlockState state) {
-        if (!multipartBlock.canPlacePartAt(world, pos) || !multipartBlock.canPlacePartOnSide(world, pos, facing))
+        IPartSlot slot = multipartBlock.getSlotForPlacement(world, pos, state, facing, hitX, hitY, hitZ, player);
+        if (!multipartBlock.canPlacePartAt(world, pos) || !multipartBlock.canPlacePartOnSide(world, pos, facing, slot))
             return false;
 
-        IPartSlot slot = multipartBlock.getSlotForPlacement(world, pos, state, facing, hitX, hitY, hitZ, player);
         if (MultipartHelper.addPart(world, pos, slot, state, false)) {
             if (!world.isRemote) {
                 IPartInfo info = MultipartHelper.getContainer(world, pos).flatMap(c -> c.get(slot)).orElse(null);

--- a/src/main/java/mcmultipart/api/multipart/IMultipart.java
+++ b/src/main/java/mcmultipart/api/multipart/IMultipart.java
@@ -281,6 +281,14 @@ public interface IMultipart {
     public default void onRemoved(IPartInfo part) {
     }
 
+    public default boolean canPlacePartAt(IBlockAccess world, BlockPos pos) {
+        return true;
+    }
+
+    public default boolean canPlacePartOnSide(IBlockAccess world, BlockPos pos, EnumFacing side) {
+        return canPlacePartAt(world, pos);
+    }
+
     public default void onPartAdded(IPartInfo part, IPartInfo otherPart) {
         onPartChanged(part, otherPart);
     }

--- a/src/main/java/mcmultipart/api/multipart/IMultipart.java
+++ b/src/main/java/mcmultipart/api/multipart/IMultipart.java
@@ -281,12 +281,12 @@ public interface IMultipart {
     public default void onRemoved(IPartInfo part) {
     }
 
-    public default boolean canPlacePartAt(IBlockAccess world, BlockPos pos) {
-        return true;
+    public default boolean canPlacePartAt(World world, BlockPos pos) {
+        return getBlock().canPlaceBlockAt(world, pos);
     }
 
-    public default boolean canPlacePartOnSide(IBlockAccess world, BlockPos pos, EnumFacing side) {
-        return canPlacePartAt(world, pos);
+    public default boolean canPlacePartOnSide(World world, BlockPos pos, EnumFacing side, IPartSlot slot) {
+        return getBlock().canPlaceBlockOnSide(world, pos, side);
     }
 
     public default void onPartAdded(IPartInfo part, IPartInfo otherPart) {

--- a/src/main/java/mcmultipart/multipart/MultipartRegistry.java
+++ b/src/main/java/mcmultipart/multipart/MultipartRegistry.java
@@ -49,7 +49,8 @@ public enum MultipartRegistry implements IMultipartRegistry {
         if (item instanceof ItemBlock) {
             wrappedBlock.setBlockPlacementLogic(
                     (stack, player, world, pos, facing, hitX, hitY, hitZ, newState) -> player.canPlayerEdit(pos, facing, stack)
-                            && world.getBlockState(pos).getBlock().isReplaceable(world, pos) && block.canPlaceBlockAt(world, pos)
+                            && world.getBlockState(pos).getBlock().isReplaceable(world, pos)
+                            && block.canPlaceBlockAt(world, pos) && block.canPlaceBlockOnSide(world, pos, facing)
                             && ((ItemBlock) item).placeBlockAt(stack, player, world, pos, facing, hitX, hitY, hitZ, newState));
         }
         STACK_WRAPPING_MAP.putIfAbsent(item, Pair.of(predicate, Pair.of(wrappedBlock, part)));


### PR DESCRIPTION
This adds a canPlaceBlockOnSide check to block placement and a canPlaceBlockAt and canPlaceBlockOnSide check to part placement.
The part placement checks could theoretically be put into seperate methods (canPlacePartAt, canPlacePartOnSide?) in IMultipart, if you wish.