### PR TITLE
Placement fix (whoops!)

### DIFF
--- a/src/main/java/mcmultipart/api/multipart/IMultipart.java
+++ b/src/main/java/mcmultipart/api/multipart/IMultipart.java
@@ -282,11 +282,11 @@ public interface IMultipart {
     }
 
     public default boolean canPlacePartAt(World world, BlockPos pos) {
-        return getBlock().canPlaceBlockAt(world, pos);
+        return true;
     }
 
     public default boolean canPlacePartOnSide(World world, BlockPos pos, EnumFacing side, IPartSlot slot) {
-        return getBlock().canPlaceBlockOnSide(world, pos, side);
+        return canPlacePartAt(world, pos);
     }
 
     public default void onPartAdded(IPartInfo part, IPartInfo otherPart) {


### PR DESCRIPTION
Old behavior checked Block#canPlaceBlockAt which, when not overridden, checks if the block at the current position is replacable which is not true for Multiparts. This should return true instead and implemented seperately by mod developers.