### PR TITLE
Fix #112

### DIFF
--- a/src/main/java/mcmultipart/block/TileMultipartContainer.java
+++ b/src/main/java/mcmultipart/block/TileMultipartContainer.java
@@ -1,18 +1,7 @@
 package mcmultipart.block;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.WeakHashMap;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Consumer;
-
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
-
 import mcmultipart.MCMultiPart;
 import mcmultipart.api.container.IMultipartContainer;
 import mcmultipart.api.container.IPartInfo;
@@ -30,17 +19,14 @@ import mcmultipart.multipart.PartInfo;
 import mcmultipart.network.MultipartNetworkHandler;
 import mcmultipart.network.PacketMultipartAdd;
 import mcmultipart.network.PacketMultipartRemove;
+import mcmultipart.util.WorldExt;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.network.play.server.SPacketUpdateTileEntity;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.EnumFacing;
-import net.minecraft.util.ITickable;
-import net.minecraft.util.Mirror;
-import net.minecraft.util.ObjectIntIdentityMap;
-import net.minecraft.util.Rotation;
+import net.minecraft.util.*;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -49,6 +35,10 @@ import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.registries.GameData;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
 
 public class TileMultipartContainer extends TileEntity implements IMultipartContainer {
 
@@ -178,11 +168,11 @@ public class TileMultipartContainer extends TileEntity implements IMultipartCont
 
         if (container != this) { // If we require ticking, place a ticking TE
             isInWorld = false;
-            getWorld().setBlockState(getPos(), MCMultiPart.multipart.getDefaultState()//
+            WorldExt.setBlockStateHack(getWorld(), getPos(), MCMultiPart.multipart.getDefaultState()//
                     .withProperty(BlockMultipartContainer.PROPERTY_TICKING, true), 0);
             getWorld().setTileEntity(getPos(), container);
         } else if (!isInWorld) { // If we aren't in the world, place the TE
-            getWorld().setBlockState(getPos(), MCMultiPart.multipart.getDefaultState()//
+            WorldExt.setBlockStateHack(getWorld(), getPos(), MCMultiPart.multipart.getDefaultState()//
                     .withProperty(BlockMultipartContainer.PROPERTY_TICKING, this instanceof Ticking), 0);
             getWorld().setTileEntity(getPos(), this);
         }

--- a/src/main/java/mcmultipart/util/WorldExt.java
+++ b/src/main/java/mcmultipart/util/WorldExt.java
@@ -1,20 +1,3 @@
-/*
- * Copyright (c) 2017 Marco Rebhan (the_real_farfetchd)
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
- * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
- * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
- * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
- * OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- */
-
 package mcmultipart.util;
 
 import net.minecraft.block.state.IBlockState;
@@ -24,10 +7,11 @@ import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
 import net.minecraftforge.fml.relauncher.ReflectionHelper;
 
-import java.lang.reflect.Field;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 
 public class WorldExt {
-    private static Field Chunk$storageArrays = ReflectionHelper.findField(Chunk.class, "storageArrays", "field_76652_q");
+    private static MethodHandle Chunk$storageArrays = findGetter(Chunk.class, "storageArrays", "field_76652_q");
 
     /**
      * Workaround that is World#setBlockState but without calling Block#breakBlock on the old block
@@ -49,14 +33,23 @@ public class WorldExt {
             int x = pos.getX() & 15;
             int y = pos.getY() & 15;
             int z = pos.getZ() & 15;
-            ExtendedBlockStorage[] storageArrays = (ExtendedBlockStorage[]) Chunk$storageArrays.get(chunk);
+            ExtendedBlockStorage[] storageArrays = (ExtendedBlockStorage[]) Chunk$storageArrays.invoke(chunk);
             ExtendedBlockStorage storage = storageArrays[pos.getY() >> 4];
             if (storage != null) storage.set(x, y, z, state);
-        } catch (IllegalAccessException e) {
+        } catch (Throwable e) { // Chunk$storageArrays.invoke throws Throwable
             e.printStackTrace();
         }
 
         self.setBlockState(pos, state, flags);
+    }
+
+    private static MethodHandle findGetter(Class<?> clazz, String... names) {
+        try {
+            return MethodHandles.lookup().unreflectGetter(ReflectionHelper.findField(clazz, names));
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+            return null;
+        }
     }
 
     private WorldExt() {}

--- a/src/main/java/mcmultipart/util/WorldExt.java
+++ b/src/main/java/mcmultipart/util/WorldExt.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2017 Marco Rebhan (the_real_farfetchd)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+ * OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package mcmultipart.util;
+
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
+import net.minecraftforge.fml.relauncher.ReflectionHelper;
+
+import java.lang.reflect.Field;
+
+public class WorldExt {
+    private static Field Chunk$storageArrays = ReflectionHelper.findField(Chunk.class, "storageArrays", "field_76652_q");
+
+    /**
+     * Workaround that is World#setBlockState but without calling Block#breakBlock on the old block
+     *
+     * @param self  The world instance
+     * @param pos   The position where the block state should be set
+     * @param state The new block state
+     * @param flags Bit set:
+     *              <p>
+     *              Flag 1 will cause a block update. Flag 2 will send the change to clients. Flag 4 will prevent the block from
+     *              being re-rendered, if this is a client world. Flag 8 will force any re-renders to run on the main thread instead
+     *              of the worker pool, if this is a client world and flag 4 is clear. Flag 16 will prevent observers from seeing
+     *              this change. Flags can be OR-ed
+     */
+    public static void setBlockStateHack(World self, BlockPos pos, IBlockState state, int flags) {
+        try {
+            Chunk chunk = self.getChunkFromBlockCoords(pos);
+
+            int x = pos.getX() & 15;
+            int y = pos.getY() & 15;
+            int z = pos.getZ() & 15;
+            ExtendedBlockStorage[] storageArrays = (ExtendedBlockStorage[]) Chunk$storageArrays.get(chunk);
+            ExtendedBlockStorage storage = storageArrays[pos.getY() >> 4];
+            if (storage != null) storage.set(x, y, z, state);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        self.setBlockState(pos, state, flags);
+    }
+
+    private WorldExt() {}
+}


### PR DESCRIPTION
Fixes #112 by setting the new block state (Multipart) into Chunk's storage arrays before calling setBlockState, thus causing it not to call breakBlock on the old block.