### PR TITLE
Fix #128

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ apply plugin: 'net.minecraftforge.gradle.forge'
 apply plugin: 'maven'
 apply plugin: 'maven-publish'
 
-String modversion = "2.5.0"
+String modversion = "2.5.1"
 
 if (System.getenv("BUILD_NUMBER") != null && System.getenv("SHOW_BUILD_NUMBER") != null) {
 	version = modversion + "_" + System.getenv("BUILD_NUMBER")

--- a/src/main/java/mcmultipart/block/BlockMultipartContainer.java
+++ b/src/main/java/mcmultipart/block/BlockMultipartContainer.java
@@ -481,12 +481,9 @@ public class BlockMultipartContainer extends Block implements ITileEntityProvide
 
     @Override
     public boolean isLadder(IBlockState state, IBlockAccess world, BlockPos pos, EntityLivingBase entity) {
-        return anyMatch(world, pos, i -> {
-            if (!(world instanceof World)) return false;
-            return i.getPart().getCollisionBoundingBox(i.getPartWorld(), pos, i.getState()).offset(pos)
-                    .intersects(entity.getEntityBoundingBox().grow(0.01 / 16F)) &&
-                    i.getPart().isLadder(i.wrapAsNeeded(world), pos, i, entity);
-        });
+        return anyMatch(world, pos, i -> i.getPart().isLadder(i.wrapAsNeeded(world), pos, i, entity) &&
+                Optional.ofNullable(i.getPart().getCollisionBoundingBox(i.getPartWorld(), pos, i.getState()).offset(pos))
+                        .map(it -> it.intersects(entity.getEntityBoundingBox().grow(0.01 / 16F))).orElse(false));
     }
 
     @Override


### PR DESCRIPTION
and a bit of cleanup/making it more efficient:
 - we don't need that instanceof World check, it isn't casted to World anywhere
 - checking isLadder first is more efficient instead of getting the bounding box and intersect checking it, most likely

*(wonders why he didn't catch that with the previous PR >_>)*