### PR TITLE
Add ITileMultipartContainerProvider to soft-depend on MCMultiPart

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ apply plugin: 'net.minecraftforge.gradle.forge'
 apply plugin: 'maven'
 apply plugin: 'maven-publish'
 
-String modversion = "2.5.3"
+String modversion = "2.5.4"
 
 if (System.getenv("BUILD_NUMBER") != null && System.getenv("SHOW_BUILD_NUMBER") != null) {
 	version = modversion + "_" + System.getenv("BUILD_NUMBER")

--- a/src/main/java/mcmultipart/MCMultiPart.java
+++ b/src/main/java/mcmultipart/MCMultiPart.java
@@ -33,6 +33,7 @@ import mcmultipart.capability.CapabilityJoiner;
 import mcmultipart.capability.CapabilityJoiner.JoinedItemHandler;
 import mcmultipart.capability.CapabilityMultipartContainer;
 import mcmultipart.capability.CapabilityMultipartTile;
+import mcmultipart.capability.CapabilityTileMultipartContainerProvider;
 import mcmultipart.multipart.MultipartRegistry;
 import mcmultipart.network.MultipartNetworkHandler;
 import mcmultipart.slot.SlotRegistry;
@@ -136,6 +137,7 @@ public class MCMultiPart {
 
 		CapabilityMultipartContainer.register();
 		CapabilityMultipartTile.register();
+		CapabilityTileMultipartContainerProvider.register();
 
 		MultipartCapabilityHelper.registerCapabilityJoiner(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY,
 				JoinedItemHandler::join);

--- a/src/main/java/mcmultipart/api/multipart/ITileMultipartContainerProvider.java
+++ b/src/main/java/mcmultipart/api/multipart/ITileMultipartContainerProvider.java
@@ -1,0 +1,7 @@
+package mcmultipart.api.multipart;
+
+import mcmultipart.block.TileMultipartContainer;
+
+public interface ITileMultipartContainerProvider {
+    TileMultipartContainer getTileMultipartContainer();
+}

--- a/src/main/java/mcmultipart/api/ref/MCMPCapabilities.java
+++ b/src/main/java/mcmultipart/api/ref/MCMPCapabilities.java
@@ -2,6 +2,7 @@ package mcmultipart.api.ref;
 
 import mcmultipart.api.container.IMultipartContainer;
 import mcmultipart.api.multipart.IMultipartTile;
+import mcmultipart.api.multipart.ITileMultipartContainerProvider;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.CapabilityInject;
 
@@ -12,5 +13,8 @@ public class MCMPCapabilities {
 
     @CapabilityInject(IMultipartContainer.class)
     public static final Capability<IMultipartContainer> MULTIPART_CONTAINER = null;
+
+    @CapabilityInject(ITileMultipartContainerProvider.class)
+    public static final Capability<ITileMultipartContainerProvider> TILE_MULTIPART_CONTAINER_PROVIDER_CAPABILITY = null;
 
 }

--- a/src/main/java/mcmultipart/block/BlockMultipartContainer.java
+++ b/src/main/java/mcmultipart/block/BlockMultipartContainer.java
@@ -4,6 +4,7 @@ import mcmultipart.MCMultiPart;
 import mcmultipart.RayTraceHelper;
 import mcmultipart.api.container.IMultipartContainerBlock;
 import mcmultipart.api.container.IPartInfo;
+import mcmultipart.api.ref.MCMPCapabilities;
 import mcmultipart.api.slot.IPartSlot;
 import mcmultipart.api.slot.SlotUtil;
 import mcmultipart.multipart.PartInfo;
@@ -67,7 +68,11 @@ public class BlockMultipartContainer extends Block implements ITileEntityProvide
 
     public static Optional<TileMultipartContainer> getTile(IBlockAccess world, BlockPos pos) {
         TileEntity te = world.getTileEntity(pos);
-        return te != null && te instanceof TileMultipartContainer ? Optional.of((TileMultipartContainer) te) : Optional.empty();
+        if (te == null) return Optional.empty();
+        if (te.hasCapability(MCMPCapabilities.TILE_MULTIPART_CONTAINER_PROVIDER_CAPABILITY, null)) {
+            return Optional.of(te.getCapability(MCMPCapabilities.TILE_MULTIPART_CONTAINER_PROVIDER_CAPABILITY, null).getTileMultipartContainer());
+        }
+        return te instanceof TileMultipartContainer ? Optional.of((TileMultipartContainer) te) : Optional.empty();
     }
 
     @Override

--- a/src/main/java/mcmultipart/capability/CapabilityTileMultipartContainerProvider.java
+++ b/src/main/java/mcmultipart/capability/CapabilityTileMultipartContainerProvider.java
@@ -1,0 +1,26 @@
+package mcmultipart.capability;
+
+import mcmultipart.api.multipart.ITileMultipartContainerProvider;
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.Capability.IStorage;
+import net.minecraftforge.common.capabilities.CapabilityManager;
+
+public class CapabilityTileMultipartContainerProvider {
+
+    public static void register() {
+        System.err.println("CapabilityTileMultipartContainerProvider REGISTERED");
+        CapabilityManager.INSTANCE.register(ITileMultipartContainerProvider.class, new IStorage<ITileMultipartContainerProvider>() {
+
+            @Override
+            public NBTBase writeNBT(Capability<ITileMultipartContainerProvider> capability, ITileMultipartContainerProvider instance, EnumFacing side) {
+                return null;
+            }
+
+            @Override
+            public void readNBT(Capability<ITileMultipartContainerProvider> capability, ITileMultipartContainerProvider instance, EnumFacing side, NBTBase nbt) {
+            }
+        }, () -> null);
+    }
+}


### PR DESCRIPTION
This code change allows LP to remove an ASM hook that would otherwise make this possible. It was originally developed in an effort to debug a compatibility issue with FMP and ProjectRed's relocation, but didn't proof to be the underlying issue.